### PR TITLE
Websocket close

### DIFF
--- a/client-api/src/main/java/it/unibo/arces/wot/sepa/api/ISubscriptionHandler.java
+++ b/client-api/src/main/java/it/unibo/arces/wot/sepa/api/ISubscriptionHandler.java
@@ -21,9 +21,29 @@ package it.unibo.arces.wot.sepa.api;
 import it.unibo.arces.wot.sepa.commons.response.ErrorResponse;
 import it.unibo.arces.wot.sepa.commons.response.Notification;
 
+/**
+ * Handles SPARQL 1.1 subscription language events.
+ *
+ * @see SPARQL11SEProtocol#SPARQL11SEProtocol(SPARQL11SEProperties, ISubscriptionHandler)
+ * @see <a href="http://wot.arces.unibo.it/TR/sparql11-subscribe.html">SPARQL 1.1 Subscribe Language</a>
+ */
 public interface ISubscriptionHandler {
-	public void onSemanticEvent(Notification notify);
-	public void onPing();
-	public void onBrokenSocket();
-	public void onError(ErrorResponse errorResponse);
+	/**
+	 * An event about changes in the graph.
+	 * @param notify notification about added and removed triples
+	 */
+	void onSemanticEvent(Notification notify);
+
+	/**
+	 * SEPA sends periodic messages to check client status.
+	 */
+	void onPing();
+
+	/**
+	 * This method is called after the connection with SEPA is lost.
+	 * Notice that it is also called even after {@link SEPAWebsocketClient#close()}
+	 * is used.
+	 */
+	void onBrokenSocket();
+	void onError(ErrorResponse errorResponse);
 }

--- a/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEProtocol.java
+++ b/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEProtocol.java
@@ -73,6 +73,12 @@ import it.unibo.arces.wot.sepa.commons.response.RegistrationResponse;
 import it.unibo.arces.wot.sepa.commons.response.Response;
 import it.unibo.arces.wot.sepa.commons.response.UpdateResponse;
 
+/**
+ * This class implements the Sparql 1.1 Secure event protocol with Sparql 1.1 subscribe language.
+ *
+ * @see <a href="http://wot.arces.unibo.it/TR/sparql11-se-protocol.html">SPARQL 1.1 Secure Event Protocol</a>
+ * @see <a href="http://wot.arces.unibo.it/TR/sparql11-subscribe.html">SPARQL 1.1 Subscribe Language</a>
+ */
 public class SPARQL11SEProtocol extends SPARQL11Protocol {
 	private static final Logger logger = LogManager.getLogger("SPARQL11SEProtocol");
 
@@ -85,7 +91,15 @@ public class SPARQL11SEProtocol extends SPARQL11Protocol {
 			throws SEPAProtocolException {
 		super(properties);
 	}
-	
+
+	/**
+	 * Create a protocol instance to communicate with SEPA. In particular
+	 * use this method if you want to subscribe about changes in the semantic
+	 * graph. Otherwise use {@link #SPARQL11SEProtocol(SPARQL11SEProperties)}
+	 * @param properties
+	 * @param handler an handler to get notification about subscribe queries
+	 * @throws SEPAProtocolException
+	 */
 	public SPARQL11SEProtocol(SPARQL11SEProperties properties, ISubscriptionHandler handler)
 			throws SEPAProtocolException {
 		super(properties);
@@ -140,24 +154,44 @@ public class SPARQL11SEProtocol extends SPARQL11Protocol {
 		return properties.toString();
 	}
 
-	// SPARQL 1.1 Update Primitive
+	/**
+	 * {@inheritDoc}
+	 */
 	public Response update(UpdateRequest request) {
 		return super.update(request, 0);
 	}
 
-	// SPARQL 1.1 Query Primitive
+	/**
+	 * {@inheritDoc}
+	 */
 	public Response query(QueryRequest request) {
 		logger.debug(request.toString());
 		return super.query(request, 0);
 	}
 
-	// SPARQL 1.1 SE Subscribe Primitive
+	/**
+	 * Subscribe with a SPARQL 1.1 Subscription language.
+	 * All the notification will be forwarded to the {@link ISubscriptionHandler}
+	 * of this instance.
+	 * @param request
+	 * @return A valid {@link Response} if the subscription is successful <br>
+	 *     an {@link ErrorResponse} otherwise
+	 */
 	public Response subscribe(SubscribeRequest request) {
 		logger.debug(request.toString());
 		return executeSPARQL11SEPrimitive(SPARQL11SEPrimitive.SUBSCRIBE, request);
 	}
 
-	// SPARQL 1.1 SE Unsubscribe Primitive
+	/**
+	 * Unsubscribe with a SPARQL 1.1 Subscription language.
+	 * Note that you must supply a SPUID that identify the subscription
+	 * that you want to delete.
+	 * This primitive does not free any resources, you must call the {@link #close()}
+	 * method.
+	 * @param request
+	 * @return A valid {@link Response} if the unsubscription is successful <br>
+	 *     an {@link ErrorResponse} otherwise
+	 */
 	public Response unsubscribe(UnsubscribeRequest request) {
 		logger.debug(request.toString());
 		return executeSPARQL11SEPrimitive(SPARQL11SEPrimitive.UNSUBSCRIBE, request);
@@ -198,6 +232,10 @@ public class SPARQL11SEProtocol extends SPARQL11Protocol {
 		return executeSPARQL11SEPrimitive(SPARQL11SEPrimitive.REQUESTTOKEN);
 	}
 
+	/**
+	 * Free the http connection manager and the WebSocket client.
+	 * @throws IOException
+	 */
     @Override
     public void close() throws IOException {
         super.close();

--- a/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEProtocol.java
+++ b/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEProtocol.java
@@ -198,11 +198,13 @@ public class SPARQL11SEProtocol extends SPARQL11Protocol {
 		return executeSPARQL11SEPrimitive(SPARQL11SEPrimitive.REQUESTTOKEN);
 	}
 
-	public void close(){
-	    wsClient.close();
+    @Override
+    public void close() throws IOException {
+        super.close();
+        wsClient.close();
     }
 
-	protected Response executeSPARQL11SEPrimitive(SPARQL11SEPrimitive op) {
+    protected Response executeSPARQL11SEPrimitive(SPARQL11SEPrimitive op) {
 		return executeSPARQL11SEPrimitive(op, null);
 	}
 

--- a/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEProtocol.java
+++ b/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEProtocol.java
@@ -198,6 +198,10 @@ public class SPARQL11SEProtocol extends SPARQL11Protocol {
 		return executeSPARQL11SEPrimitive(SPARQL11SEPrimitive.REQUESTTOKEN);
 	}
 
+	public void close(){
+	    wsClient.close();
+    }
+
 	protected Response executeSPARQL11SEPrimitive(SPARQL11SEPrimitive op) {
 		return executeSPARQL11SEPrimitive(op, null);
 	}

--- a/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEWebsocket.java
+++ b/client-api/src/main/java/it/unibo/arces/wot/sepa/api/SPARQL11SEWebsocket.java
@@ -110,4 +110,11 @@ public class SPARQL11SEWebsocket implements ISubscriptionHandler {
 	public void onError(ErrorResponse errorResponse) {
 		handler.onError(errorResponse);
 	}
+
+	public void close() {
+		if (connected){
+				client.close();
+		}
+	}
+
 }

--- a/commons/src/main/java/it/unibo/arces/wot/sepa/commons/protocol/SPARQL11Protocol.java
+++ b/commons/src/main/java/it/unibo/arces/wot/sepa/commons/protocol/SPARQL11Protocol.java
@@ -57,7 +57,7 @@ import org.apache.logging.log4j.LogManager;
  * This class implements the SPARQL 1.1 Protocol
  */
 
-public class SPARQL11Protocol {
+public class SPARQL11Protocol implements java.io.Closeable {
 
 	/** The Constant logger. */
 	private static final Logger logger = LogManager.getLogger("SPARQL11Protocol");
@@ -329,5 +329,10 @@ public class SPARQL11Protocol {
 		}
 
 		return new QueryResponse(req.getToken(), new JsonParser().parse(responseBody).getAsJsonObject());
+	}
+
+	@Override
+	public void close() throws IOException {
+		httpClient.close();
 	}
 }


### PR DESCRIPTION
This pull request adds closing methods to client side API. It' a trivial change but it's important to free the underlying resources. 

I just want to point out that the close method in web socket client is asynchronous and when the connection is actually closed the method onBrokenSocket() of the user handler is called.  Should we add a specific onClose method? Or a simple javadoc warning about this would be enough? 