### PR TITLE
Modify add alias to ErrorResponse

### DIFF
--- a/client-api/src/main/java/it/unibo/arces/wot/sepa/commons/response/ErrorResponse.java
+++ b/client-api/src/main/java/it/unibo/arces/wot/sepa/commons/response/ErrorResponse.java
@@ -178,6 +178,14 @@ public class ErrorResponse extends Response {
 	}
 
 	/**
+	 * When error is refered to a subscription it may optionally has the corrisponding
+	 * alias. This method sets this alias
+	 * @param alias
+	 */
+	public void setAlias(String alias){
+		json.add("alias",new JsonPrimitive(alias));
+	}
+	/**
 	 * Gets the HTTP status code.
 	 *
 	 * @return the HTTP status code

--- a/engine/src/main/java/it/unibo/arces/wot/sepa/engine/processing/subscriptions/SPUManager.java
+++ b/engine/src/main/java/it/unibo/arces/wot/sepa/engine/processing/subscriptions/SPUManager.java
@@ -117,6 +117,9 @@ public class SPUManager implements SPUManagerMBean, EventHandler {
 			Response init = spu.init();
 			if (init.isError()) {
 				logger.error("@subscribe SPU initialization failed: " + init);
+				if(alias != null) {
+					((ErrorResponse) init).setAlias(alias);
+				}
 				return init;
 			}
 


### PR DESCRIPTION
if a client uses a mono-socket connection it needs to know which subscription
has failed. Adding an alias to the ErrorResponse solves this problem.
Alias is optional and is returned only if the request contains it.